### PR TITLE
Add normalized scanned ingredients and search

### DIFF
--- a/SafeBite-Backend-H6.API/Data/Migrations/App/20260505102719_NormalizedIngredientList.Designer.cs
+++ b/SafeBite-Backend-H6.API/Data/Migrations/App/20260505102719_NormalizedIngredientList.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SafeBite_Backend_H6.API.Data.AppDb;
@@ -11,9 +12,11 @@ using SafeBite_Backend_H6.API.Data.AppDb;
 namespace SafeBite_Backend_H6.API.Data.Migrations.App
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260505102719_NormalizedIngredientList")]
+    partial class NormalizedIngredientList
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/SafeBite-Backend-H6.API/Data/Migrations/App/20260505102719_NormalizedIngredientList.cs
+++ b/SafeBite-Backend-H6.API/Data/Migrations/App/20260505102719_NormalizedIngredientList.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SafeBite_Backend_H6.API.Data.Migrations.App
+{
+    /// <inheritdoc />
+    public partial class NormalizedIngredientList : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "NormalizedScannedIngredientsText",
+                table: "Scans",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "NormalizedScannedIngredientsText",
+                table: "Scans");
+        }
+    }
+}

--- a/SafeBite-Backend-H6.API/Entities/Scans/Scan.cs
+++ b/SafeBite-Backend-H6.API/Entities/Scans/Scan.cs
@@ -7,6 +7,6 @@ public class Scan
     public string? Name { get; set; }
     public DateTime ScannedAt { get; set; }
     public string ScannedIngredientsText { get; set; } = string.Empty;
-
+    public string NormalizedScannedIngredientsText { get; set; } = string.Empty;
     public ICollection<ScanDetectedAllergies> DetectedAllergies { get; set; } = [];
 }

--- a/SafeBite-Backend-H6.API/Mappings/ScanMappings.cs
+++ b/SafeBite-Backend-H6.API/Mappings/ScanMappings.cs
@@ -11,6 +11,7 @@ public static class ScanMappings
             Name = !string.IsNullOrWhiteSpace(name) ? StringHelpers.ToTitleCase(name) : null,
             ScannedAt = DateTime.UtcNow,
             ScannedIngredientsText = rawIngredientsText,
+            NormalizedScannedIngredientsText = StringHelpers.NormalizeName(rawIngredientsText),
             DetectedAllergies = analysisResult.DetectedAllergies
                 .Select(ToScanDetectedAllergyEntity)
                 .ToList()

--- a/SafeBite-Backend-H6.API/Repositories/ScanRepository.cs
+++ b/SafeBite-Backend-H6.API/Repositories/ScanRepository.cs
@@ -31,7 +31,8 @@ public class ScanRepository : BaseRepository<Scan>, IScanRepository
 
                       (da.CustomAllergy != null &&
                        da.CustomAllergy.NormalizedName.Contains(normalized))
-                  )
+                  ) ||
+                  s.NormalizedScannedIngredientsText.Contains(normalized)
               );
         }
 


### PR DESCRIPTION
Introduce a NormalizedScannedIngredientsText property on Scan and persist it with a new EF Core migration (20260505102719_NormalizedIngredientList). Populate the field in ScanMappings using StringHelpers.NormalizeName and update ScanRepository search to include the normalized text in contains checks. This enables more reliable, normalized ingredient matching and searching and updates the model snapshot accordingly.