### PR TITLE
Make rate limits and testing services configurable

### DIFF
--- a/SafeBite-Backend-H6.API/Program.cs
+++ b/SafeBite-Backend-H6.API/Program.cs
@@ -3,13 +3,6 @@
 var builder = WebApplication.CreateBuilder(args);
 
 
-// also load secrests in loadtest environment. standard is it only loads in development - this is made behind the scenes.
-if (builder.Environment.IsDevelopment() || builder.Environment.IsEnvironment("LoadTest"))
-{
-    builder.Configuration.AddUserSecrets<Program>();
-}
-
-
 builder.Services.AddDbContext<AppDbContext>(options =>
     options.UseNpgsql(builder.Configuration.GetConnectionString("AppConnection")));
 
@@ -33,7 +26,9 @@ builder.Services
 builder.Services.AddRateLimiter(options =>
 {
     options.RejectionStatusCode = StatusCodes.Status429TooManyRequests; // proper status code instead of 503
-
+    var adminLimit = builder.Configuration.GetValue<int>("RateLimiting:Global:AdminPermitLimit");
+    var userLimit = builder.Configuration.GetValue<int>("RateLimiting:Global:UserPermitLimit");
+    var scanLimit = builder.Configuration.GetValue<int>("RateLimiting:Scan:PermitLimit");
 
     // global limit applies different limits for admins and non-admins.
     options.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(httpContext =>
@@ -47,7 +42,7 @@ builder.Services.AddRateLimiter(options =>
 
         return RateLimitPartition.GetFixedWindowLimiter(partitionKey, _ => new FixedWindowRateLimiterOptions
         {
-            PermitLimit = isAdmin ? 200 : 50,
+            PermitLimit = isAdmin ? adminLimit : userLimit,
             Window = TimeSpan.FromMinutes(1),
             QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
             QueueLimit = 0,
@@ -67,7 +62,7 @@ builder.Services.AddRateLimiter(options =>
             $"Scan:{userId}",
             _ => new FixedWindowRateLimiterOptions
             {
-                PermitLimit = 10,
+                PermitLimit = scanLimit,
                 Window = TimeSpan.FromMinutes(1),
                 QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
                 QueueLimit = 4,
@@ -113,18 +108,25 @@ builder.Services.AddScoped<IAllergyMatcher, AllergyMatcher>();
 
 builder.Services.AddTransient<IEmailSender, EmailSender>();
 
-
-if(builder.Environment.IsEnvironment("LoadTest"))
+var useFakeOcr = builder.Configuration.GetValue<bool>("Testing:UseFakeOcr");
+if (useFakeOcr)
 {
     builder.Services.AddScoped<IOcrService, FakeOcrService>();
-    builder.Services.AddScoped<IScanAnalysisService, FakeScanAnalysisService>();
 }
 else
 {
     builder.Services.AddScoped<IOcrService, OcrService>();
-    builder.Services.AddScoped<IScanAnalysisService, ScanAnalysisService>();
 }
 
+var useFakeScan = builder.Configuration.GetValue<bool>("Testing:UseFakeScan");
+if (useFakeScan)
+{
+    builder.Services.AddScoped<IScanAnalysisService, FakeScanAnalysisService>();
+}
+else
+{
+    builder.Services.AddScoped<IScanAnalysisService, ScanAnalysisService>();
+}
 
 # endregion
 
@@ -159,7 +161,7 @@ using (var scope = app.Services.CreateScope())
 }
 
 // Configure the HTTP request pipeline.
-if (app.Environment.IsDevelopment() || builder.Environment.IsEnvironment("LoadTest"))
+if (app.Environment.IsDevelopment())
 {
     app.MapOpenApi();
 
@@ -176,17 +178,15 @@ if (app.Environment.IsDevelopment() || builder.Environment.IsEnvironment("LoadTe
     });
 }
 
-app.UseAuthentication();
 app.UseHttpsRedirection();
-
-app.UseAuthorization();
 
 app.UseCors("AllowAllOrigins");
 
-if (!builder.Environment.IsEnvironment("LoadTest"))
-{
-    app.UseRateLimiter();
-}
+app.UseAuthentication();
+
+app.UseRateLimiter();
+
+app.UseAuthorization();
 
 app.MapControllers();
 app.MapGroup("/auth").MapCustomIdentityApi<ApplicationUser>();

--- a/SafeBite-Backend-H6.API/Program.cs
+++ b/SafeBite-Backend-H6.API/Program.cs
@@ -118,7 +118,7 @@ else
     builder.Services.AddScoped<IOcrService, OcrService>();
 }
 
-var useFakeScan = builder.Configuration.GetValue<bool>("Testing:UseFakeScan");
+var useFakeScan = builder.Configuration.GetValue<bool>("Testing:UseFakeScanAnalysis");
 if (useFakeScan)
 {
     builder.Services.AddScoped<IScanAnalysisService, FakeScanAnalysisService>();

--- a/SafeBite-Backend-H6.API/appsettings.Development.json
+++ b/SafeBite-Backend-H6.API/appsettings.Development.json
@@ -4,5 +4,20 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+
+  "RateLimiting": {
+    "Global": {
+      "AdminPermitLimit": 10000,
+      "UserPermitLimit": 5000
+    },
+    "Scan": {
+      "PermitLimit": 500
+    }
+  },
+
+  "Testing": {
+    "UseFakeOcr": true,
+    "UseFakeScanAnalysis": true
   }
 }

--- a/SafeBite-Backend-H6.API/appsettings.json
+++ b/SafeBite-Backend-H6.API/appsettings.json
@@ -5,5 +5,18 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "RateLimiting": {
+    "Global": {
+      "AdminPermitLimit": 200,
+      "UserPermitLimit": 50
+    },
+    "Scan": {
+      "PermitLimit": 10
+    }
+  },
+  "Testing": {
+    "UseFakeOcr": false,
+    "UseFakeScanAnalysis": false
+  }
 }

--- a/SafeBite-Backend-H6.Load/LoadTestProgram.cs
+++ b/SafeBite-Backend-H6.Load/LoadTestProgram.cs
@@ -13,14 +13,15 @@ using SafeBite_Backend_H6.Load.Utility;
 
 public partial class LoadTestProgram
 {
-    private const string baseUrl = "https://localhost:7002";
     private static async Task Main(string[] args)
     {
+
+
         Console.ForegroundColor = ConsoleColor.Red;
 
         Console.WriteLine("""
         WARNING:
-        Make sure the API is running in the LoadTest environment.
+        Make sure the Development API is deployed with fake OCR and fake scan analysis enabled.
 
         Run the API with:
         dotnet run --launch-profile loadtest
@@ -44,6 +45,8 @@ public partial class LoadTestProgram
         var config = new ConfigurationBuilder()
             .AddUserSecrets<LoadTestProgram>()
             .Build();
+
+        var baseUrl = config["Api:BaseUrl"] ?? throw new InvalidOperationException("BaseUrl missing.");
 
         var email = config["User:AdminEmail"] ?? throw new InvalidOperationException("Admin email is not configured.");
         var password = config["User:AdminPassword"] ?? throw new InvalidOperationException("Admin password is not configured.");


### PR DESCRIPTION
Read rate limits and testing toggles from configuration and wire them into startup. Rate limits (Global/Admin/User and Scan) are now obtained from settings instead of hard-coded values and corresponding entries were added to appsettings.json and appsettings.Development.json. OCR and scan-analysis implementations are selected via Testing flags (fake vs real) and registered from configuration. Simplified environment handling by removing special LoadTest user-secrets loading and treating OpenAPI mapping as development-only. Adjusted middleware ordering to consistently enable authentication, rate limiting, and authorization. Load test program now reads the API base URL from configuration and updates the warning/instructions.